### PR TITLE
switch github-tag-version from github3.py -> pygithub

### DIFF
--- a/codekit/cli/github_tag_teams.py
+++ b/codekit/cli/github_tag_teams.py
@@ -8,9 +8,9 @@ import github
 import itertools
 import re
 from getpass import getuser
-from github import Github
 from .. import codetools
 from .. import info, debug
+from codekit import pygithub
 
 logger = logging.getLogger('codekit')
 logging.basicConfig()
@@ -144,12 +144,6 @@ def find_repo_teams(repo):
     return teams
 
 
-def login_github(token_path=None, token=None):
-    """pygithub equiv of codetools.login_github()"""
-    token = codetools.github_token(token_path=token_path, token=token)
-    return Github(token)
-
-
 def tag_repo(repo, tags, tagger, dry_run=False):
     # tag the head of the designated "default branch"
     # XXX this probably should be resolved via repos.yaml
@@ -208,7 +202,7 @@ def main():
     )
     debug(tagger)
 
-    g = login_github(token=args.token)
+    g = pygithub.login_github(token=args.token)
     org = g.get_organization(gh_org_name)
 
     teams = org.get_teams()

--- a/codekit/cli/github_tag_teams.py
+++ b/codekit/cli/github_tag_teams.py
@@ -78,19 +78,6 @@ def parse_args():
     return parser.parse_args()
 
 
-def find_tag_by_name(repo, tag_name):
-    tagfmt = 'tags/{ref}'.format(ref=tag_name)
-
-    try:
-        ref = repo.get_git_ref(tagfmt)
-        if ref and ref.ref:
-            return ref
-    except github.GithubException as e:
-        pass
-
-    return None
-
-
 def find_repos_missing_tags(repos, tags):
     debug("looking for repos WITHOUT {tags}".format(tags=tags))
     need = {}
@@ -118,7 +105,7 @@ def find_tags_in_repo(repo, tags):
     ))
     found_tags = []
     for t in tags:
-        ref = find_tag_by_name(repo, t)
+        ref = pygithub.find_tag_by_name(repo, t)
         if ref and ref.ref:
             debug("  found: {tag}".format(tag=t))
             found_tags.append(re.sub(r'^refs/tags/', '', ref.ref))

--- a/codekit/pygithub.py
+++ b/codekit/pygithub.py
@@ -1,0 +1,35 @@
+"""
+pygithub based functions intended to replace the github3.py based functions in
+codetools.
+"""
+
+import logging
+from public import public
+from github import Github
+import codekit.codetools as codetools
+
+logging.basicConfig()
+logger = logging.getLogger('codekit')
+
+
+@public
+def login_github(token_path=None, token=None):
+    """Log into GitHub using an existing token.
+
+    Parameters
+    ----------
+    token_path : str, optional
+        Path to the token file. The default token is used otherwise.
+
+    token: str, optional
+        Literial token string. If specifified, this value is used instead of
+        reading from the token_path file.
+
+    Returns
+    -------
+    gh : :class:`github.GitHub` instance
+        A GitHub login instance.
+    """
+
+    token = codetools.github_token(token_path=token_path, token=token)
+    return Github(token)

--- a/codekit/pygithub.py
+++ b/codekit/pygithub.py
@@ -37,7 +37,7 @@ def login_github(token_path=None, token=None):
 
 
 @public
-def find_tag_by_name(repo, tag_name):
+def find_tag_by_name(repo, tag_name, safe=True):
     """Find tag by name in a github Repository
 
     Parameters
@@ -47,9 +47,18 @@ def find_tag_by_name(repo, tag_name):
     tag_name: str
         Short name of tag (not a fully qualified ref).
 
+    safe: bool, optional
+        Defaults to `True`. When `True`, `None` is returned on failure. When
+        `False`, an exception will be raised upon failure.
+
     Returns
     -------
     gh : :class:`github.GitRef` instance or `None`
+
+    Raises
+    ------
+    github.UnknownObjectException
+        If git tag name does not exist in repo.
     """
     tagfmt = 'tags/{ref}'.format(ref=tag_name)
 
@@ -58,6 +67,7 @@ def find_tag_by_name(repo, tag_name):
         if ref and ref.ref:
             return ref
     except github.UnknownObjectException:
-        pass
+        if not safe:
+            raise
 
     return None

--- a/codekit/pygithub.py
+++ b/codekit/pygithub.py
@@ -4,9 +4,10 @@ codetools.
 """
 
 import logging
+import github
+import codekit.codetools as codetools
 from public import public
 from github import Github
-import codekit.codetools as codetools
 
 logging.basicConfig()
 logger = logging.getLogger('codekit')
@@ -33,3 +34,30 @@ def login_github(token_path=None, token=None):
 
     token = codetools.github_token(token_path=token_path, token=token)
     return Github(token)
+
+
+@public
+def find_tag_by_name(repo, tag_name):
+    """Find tag by name in a github Repository
+
+    Parameters
+    ----------
+    repo: :class:`github.Repository` instance
+
+    tag_name: str
+        Short name of tag (not a fully qualified ref).
+
+    Returns
+    -------
+    gh : :class:`github.GitRef` instance or `None`
+    """
+    tagfmt = 'tags/{ref}'.format(ref=tag_name)
+
+    try:
+        ref = repo.get_git_ref(tagfmt)
+        if ref and ref.ref:
+            return ref
+    except github.UnknownObjectException:
+        pass
+
+    return None


### PR DESCRIPTION
This allows the fork of github3.py, with tag updating support, to be
dropped and makes github-tag-version consistent with github-tag-teams.