### PR TITLE
fail tagging if repo is not a member of a target team

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,10 @@ matrix:
           github-tag-version \
             --dry-run \
             --org 'lsst' \
-            --team 'Data Management' \
-            --team 'DM Externals' \
+            --allow-team 'Data Management' \
+            --allow-team 'DM Externals' \
+            --external-team 'DM Externals' \
+            --deny-team 'DM Auxilliaries' \
             --email 'sqre-admin@lists.lsst.org' \
             --user 'sqreadmin' \
             --token "$SQREADMIN_TOKEN" \

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,16 +42,14 @@ matrix:
           github-tag-teams \
             --dry-run \
             --org 'lsst' \
-            --team 'DM Auxilliaries' \
+            --allow-team 'DM Auxilliaries' \
+            --deny-team 'DM Externals' \
             --token "$SQREADMIN_TOKEN" \
             --user 'sqreadmin' \
             --email 'sqre-admin@lists.lsst.org' \
             --debug \
             --tag 'foo' \
-            --tag '13.0' \
-            --tag '14.0' \
-            --tag '15.0' \
-            --tag 'w.2018.18'
+            --tag 'bar'
         else
           echo "Unable to test without travis secure env vars."
         fi

--- a/codekit/cli/github_decimate_org.py
+++ b/codekit/cli/github_decimate_org.py
@@ -56,15 +56,14 @@ def parse_args():
     parser.add_argument('--dry-run', action='store_true')
     parser.add_argument(
         '--fail-fast',
-        default=True,
         action='store_true',
-        help='Fail immediately on github API errors. (default)')
+        help='Fail immediately on github API errors.')
     parser.add_argument(
         '--no-fail-fast',
         action='store_const',
         const=False,
         dest='fail_fast',
-        help='DO NOT Fail immediately on github API errors.')
+        help='DO NOT Fail immediately on github API errors. (default)')
     parser.add_argument(
         '-d', '--debug',
         action='count',

--- a/codekit/cli/github_fork_org.py
+++ b/codekit/cli/github_fork_org.py
@@ -67,15 +67,14 @@ def parse_args():
         """))
     parser.add_argument(
         '--fail-fast',
-        default=True,
         action='store_true',
-        help='Fail immediately on github API errors. (default)')
+        help='Fail immediately on github API errors.')
     parser.add_argument(
         '--no-fail-fast',
         action='store_const',
         const=False,
         dest='fail_fast',
-        help='DO NOT Fail immediately on github API errors.')
+        help='DO NOT Fail immediately on github API errors. (default)')
     parser.add_argument('--dry-run', action='store_true')
     parser.add_argument(
         '-d', '--debug',

--- a/codekit/cli/github_tag_teams.py
+++ b/codekit/cli/github_tag_teams.py
@@ -6,6 +6,7 @@ from .. import info, debug
 import argparse
 import github
 import logging
+import os
 import re
 import sys
 import textwrap
@@ -71,6 +72,7 @@ def parse_args():
     parser.add_argument(
         '-d', '--debug',
         action='count',
+        default=os.getenv('DM_SQUARE_DEBUG'),
         help='Debug mode')
     parser.add_argument('-v', '--version', action=codetools.ScmVersionAction)
     return parser.parse_args()

--- a/codekit/cli/github_tag_version.py
+++ b/codekit/cli/github_tag_version.py
@@ -226,18 +226,18 @@ def eups_products_to_gh_repos(
         repo_team_names = [t.name for t in repo.get_teams()]
         debug("  teams: {teams}".format(teams=repo_team_names))
 
-        if not any(x in repo_team_names for x in allow_teams)\
-           or any(x in repo_team_names for x in deny_teams):
-            yikes = pygithub.RepositoryTeamMembershipError(
+        try:
+            pygithub.check_repo_teams(
                 repo,
-                repo_team_names,
                 allow_teams=allow_teams,
-                deny_teams=deny_teams
+                deny_teams=deny_teams,
+                team_names=repo_team_names
             )
+        except pygithub.RepositoryTeamMembershipError as e:
             if fail_fast:
-                raise yikes
-            problems.append(yikes)
-            error(yikes)
+                raise
+            problems.append(e)
+            error(e)
 
             continue
 

--- a/codekit/cli/github_tag_version.py
+++ b/codekit/cli/github_tag_version.py
@@ -37,29 +37,6 @@ class GitTagExistsError(Exception):
     pass
 
 
-class RepositoryTeamMembershipError(Exception):
-    def __init__(self, repo, repo_team_names, allow_teams, deny_teams):
-        assert isinstance(repo, github.Repository.Repository), type(repo)
-
-        self.repo = repo
-        self.repo_team_names = repo_team_names
-        self.allow_teams = allow_teams
-        self.deny_teams = deny_teams
-
-    def __str__(self):
-        return textwrap.dedent("""\
-            Invalid team membership for {repo}
-              has teams:     {repo_teams}
-              allowed teams: {allow}
-              denied teams:  {deny}\
-            """.format(
-            repo=self.repo.full_name,
-            repo_teams=self.repo_team_names,
-            allow=self.allow_teams,
-            deny=self.deny_teams,
-        ))
-
-
 class DogpileError(Exception):
     def __init__(self, errors, msg):
         self.errors = errors
@@ -251,7 +228,7 @@ def eups_products_to_gh_repos(
 
         if not any(x in repo_team_names for x in allow_teams)\
            or any(x in repo_team_names for x in deny_teams):
-            yikes = RepositoryTeamMembershipError(
+            yikes = pygithub.RepositoryTeamMembershipError(
                 repo,
                 repo_team_names,
                 allow_teams=allow_teams,

--- a/codekit/cli/github_tag_version.py
+++ b/codekit/cli/github_tag_version.py
@@ -98,6 +98,12 @@ def parse_args():
         action='store_true',
         help='Fail immediately on github API errors.')
     parser.add_argument(
+        '--no-fail-fast',
+        action='store_const',
+        const=False,
+        dest='fail_fast',
+        help='DO NOT Fail immediately on github API errors. (default)')
+    parser.add_argument(
         '-d', '--debug',
         action='count',
         default=os.getenv('DM_SQUARE_DEBUG'),

--- a/codekit/cli/github_tag_version.py
+++ b/codekit/cli/github_tag_version.py
@@ -289,8 +289,8 @@ def check_existing_git_tag(repo, t_tag):
 
     Parameters
     ----------
-    repo : dict
-        dict representing a target github repo
+    repo : github.Repository.Repository
+        repo to inspect for an existing tagsdf
     t_tag: dict
         dict repesenting a target git tag
 
@@ -305,17 +305,20 @@ def check_existing_git_tag(repo, t_tag):
         If tag exists but is not in sync.
     """
 
+    assert isinstance(repo, github.Repository.Repository), type(repo)
+    assert isinstance(t_tag, dict)
+
     debug("looking for existing tag: {tag}"
           .format(tag=t_tag['name']))
 
     # find ref/tag by name
-    e_ref = pygithub.find_tag_by_name(repo['repo'], t_tag['name'])
+    e_ref = pygithub.find_tag_by_name(repo, t_tag['name'])
     if not e_ref:
         debug("  not found: {tag}".format(tag=t_tag['name']))
         return False
 
     # find tag object pointed to by the ref
-    e_tag = repo['repo'].get_git_tag(e_ref.object.sha)
+    e_tag = repo.get_git_tag(e_ref.object.sha)
     debug("  found existing tag: {tag}".format(tag=e_tag))
 
     if cmp_existing_git_tag(t_tag, e_tag):
@@ -374,7 +377,7 @@ def tag_gh_repos(
 
         try:
             # if the existing tag is in sync, do nothing
-            if check_existing_git_tag(repo, t_tag):
+            if check_existing_git_tag(repo['repo'], t_tag):
                 warn(textwrap.dedent("""\
                     No action for {repo}
                       existing tag: {tag} is already in sync\

--- a/codekit/cli/github_tag_version.py
+++ b/codekit/cli/github_tag_version.py
@@ -154,20 +154,19 @@ def eups_products_to_gh_repos(
     org,
     teams,
     eupsbuild,
-    eups_products,
-    debug=False
+    eups_products
 ):
     gh_repos = []
 
     for prod in eups_products:
-        codetools.debug("looking for git repo for: {prod} [{ver}]".format(
+        debug("looking for git repo for: {prod} [{ver}]".format(
             prod=prod['name'],
             ver=prod['eups_version']
         ))
 
         repo = org.get_repo(prod['name'])
 
-        codetools.debug("  found: {slug}".format(slug=repo.full_name))
+        debug("  found: {slug}".format(slug=repo.full_name))
 
         repo_teams = [t.name for t in repo.get_teams()]
         if not any(x in repo_teams for x in teams):
@@ -185,8 +184,7 @@ def eups_products_to_gh_repos(
         sha = codetools.eups2git_ref(
             product=repo.name,
             eups_version=prod['eups_version'],
-            build_id=eupsbuild,
-            debug=debug
+            build_id=eupsbuild
         )
 
         gh_repos.append({
@@ -452,8 +450,7 @@ def run():
         org,
         args.team,
         eupsbuild,
-        eups_products,
-        args.debug
+        eups_products
     )
     tag_gh_repos(gh_repos, args, tag_template)
 

--- a/codekit/cli/github_tag_version.py
+++ b/codekit/cli/github_tag_version.py
@@ -79,10 +79,17 @@ def parse_args():
         Tag all repositories in a GitHub org using a team-based scheme
 
         Examples:
-        github-tag-version --org lsst --team 'Data Management' w.2015.33 b1630
+        github-tag-version \\
+            --org lsst \\
+            --allow-team 'Data Management' \\
+            w.2015.33 b1630
 
-        github-tag-version --org lsst --team 'Data Management' \
-            --team 'External' --candidate v11_0_rc2 11.0.rc2 b1679
+        github-tag-version \\
+            --org lsst \\
+            --allow-team 'Data Management' \\
+            --allow-team 'DM Externals' \\
+            --candidate \\
+            v11_0_rc2 11.0.rc2 b1679
 
         Note that the access token must have access to these oauth scopes:
             * read:org
@@ -101,16 +108,16 @@ def parse_args():
         required=True,
         help="Github organization")
     parser.add_argument(
-        '--team',
+        '--allow-team',
         action='append',
         required=True,
         help='git repos to be tagged MUST be a member of ONE or more of'
-             ' these teams (can specify several times')
+             ' these teams (can specify several times)')
     parser.add_argument(
         '--deny-team',
         action='append',
         help='git repos to be tagged MUST NOT be a member of ANY of'
-             ' these teams (can specify several times')
+             ' these teams (can specify several times)')
     parser.add_argument('--candidate')
     parser.add_argument('--dry-run', action='store_true')
     parser.add_argument(
@@ -538,7 +545,7 @@ def run():
     # do not fail-fast on non-write operations
     gh_repos = eups_products_to_gh_repos(
         org,
-        args.team,
+        args.allow_team,
         args.deny_team,
         eupsbuild,
         eups_products,

--- a/codekit/cli/github_tag_version.py
+++ b/codekit/cli/github_tag_version.py
@@ -15,10 +15,9 @@ Use URL to EUPS candidate tag file to git tag repos with official version
 # Yeah, the candidate logic is broken, will fix
 
 
-from .. import codetools
+from codekit import codetools, pygithub
 from .. import debug, warn, error
 import argparse
-import codekit.pygithub as pygithub
 import copy
 import github
 import logging
@@ -35,15 +34,6 @@ eupspkg_site = 'https://eups.lsst.codes/stack/src'
 
 class GitTagExistsError(Exception):
     pass
-
-
-class DogpileError(Exception):
-    def __init__(self, errors, msg):
-        self.errors = errors
-        self.msg = msg
-
-    def __str__(self):
-        return self.msg + "\n" + "\n".join([str(e) for e in self.errors])
 
 
 def parse_args():
@@ -260,7 +250,7 @@ def eups_products_to_gh_repos(
 
     if problems:
         msg = "{n} repo(s) have errors".format(n=len(problems))
-        raise DogpileError(problems, msg)
+        raise codetools.DogpileError(problems, msg)
 
     return gh_repos
 
@@ -477,7 +467,7 @@ def tag_gh_repos(
 
     if problems:
         msg = "{n} tag failures".format(n=len(problems))
-        raise DogpileError(problems, msg)
+        raise codetools.DogpileError(problems, msg)
 
 
 def run():
@@ -530,7 +520,7 @@ def run():
     global g
     g = pygithub.login_github(token_path=args.token_path, token=args.token)
     org = g.get_organization(args.org)
-    debug("tagging repos in github org: {org}".format(org=org.login))
+    debug("tagging repos in org: {org}".format(org=org.login))
 
     # generate eups-style version
     # eups no likey semantic versioning markup, wants underscores
@@ -563,7 +553,7 @@ def run():
 def main():
     try:
         run()
-    except DogpileError as e:
+    except codetools.DogpileError as e:
         error(e)
         n = len(e.errors)
         sys.exit(n if n < 256 else 255)

--- a/codekit/cli/github_tag_version.py
+++ b/codekit/cli/github_tag_version.py
@@ -333,9 +333,9 @@ def check_existing_git_tag(repo, t_tag):
             tagger: {t_tagger}\
     """).format(
         tag=t_tag['name'],
-        e_sha=e_tag['sha'],
-        e_message=e_tag['message'],
-        e_tagger=e_tag['tagger'],
+        e_sha=e_tag.sha,
+        e_message=e_tag.message,
+        e_tagger=e_tag.tagger,
         t_sha=t_tag['sha'],
         t_message=t_tag['message'],
         t_tagger=t_tag['tagger'],

--- a/codekit/codetools.py
+++ b/codekit/codetools.py
@@ -48,6 +48,16 @@ class ScmVersionAction(argparse.Action):
         parser.exit()
 
 
+class DogpileError(Exception):
+    """Aggregate list of exceptions"""
+    def __init__(self, errors, msg):
+        self.errors = errors
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg + "\n" + "\n".join([str(e) for e in self.errors])
+
+
 @public
 def lookup_email(args):
     """Return the email address to use when creating git objects or exit

--- a/codekit/codetools.py
+++ b/codekit/codetools.py
@@ -182,12 +182,11 @@ def github_2fa_callback():
 def fetch_manifest_file(
     build_id,
     versiondb='https://raw.githubusercontent.com'
-              '/lsst/versiondb/master/manifests',
-    debug=False
+              '/lsst/versiondb/master/manifests'
 ):
     # eg. https://raw.githubusercontent.com/lsst/versiondb/master/manifests/b1108.txt  # NOQA
     shafile = versiondb + '/' + build_id + '.txt'
-    logger.debug("fetching: {url}".format(url=shafile))
+    debug("fetching: {url}".format(url=shafile))
 
     # Get the file tying shas to eups versions
     r = requests.get(shafile)
@@ -228,12 +227,11 @@ def parse_manifest_file(data):
 def eups2git_ref(
     product,
     eups_version,
-    build_id,
-    debug=False
+    build_id
 ):
     """Provide the sha1 for an EUPS product."""
 
-    manifest = fetch_manifest_file(build_id, debug=debug)
+    manifest = fetch_manifest_file(build_id)
     products = parse_manifest_file(manifest)
 
     entry = products[product]

--- a/codekit/pygithub.py
+++ b/codekit/pygithub.py
@@ -22,18 +22,18 @@ class CaughtRepositoryError(Exception):
     """
     def __init__(self, repo, caught):
         assert isinstance(repo, github.Repository.Repository), type(repo)
-        assert isinstance(caught, Exception)
+        assert isinstance(caught, github.GithubException), type(caught)
 
         self.repo = repo
         self.caught = caught
 
     def __str__(self):
         return textwrap.dedent("""\
-            Caught: {name}
+            Caught: {cls}
               In repo: {repo}
               Message: {e}\
             """.format(
-            name=type(self.caught),
+            cls=type(self.caught),
             repo=self.repo.full_name,
             e=str(self.caught)
         ))
@@ -45,18 +45,18 @@ class CaughtTeamError(Exception):
     """
     def __init__(self, team, caught):
         assert isinstance(team, github.Team.Team), type(team)
-        assert isinstance(caught, Exception)
+        assert isinstance(caught, github.GithubException), type(caught)
 
         self.team = team
         self.caught = caught
 
     def __str__(self):
         return textwrap.dedent("""\
-            Caught: {name}
+            Caught: {cls}
               In team: {team}@{org}
               Message: {e}\
             """.format(
-            name=type(self.caught),
+            cls=type(self.caught),
             team=self.team.slug,
             org=self.team.organization.login,
             e=str(self.caught)
@@ -69,18 +69,18 @@ class CaughtOrganizationError(Exception):
     """
     def __init__(self, org, caught):
         assert isinstance(org, github.Organization.Organization), type(org)
-        assert isinstance(caught, Exception)
+        assert isinstance(caught, github.GithubException), type(caught)
 
         self.org = org
         self.caught = caught
 
     def __str__(self):
         return textwrap.dedent("""\
-            Caught: {name}
+            Caught: {cls}
               In org: {org}
               Message: {e}\
             """.format(
-            name=type(self.caught),
+            cls=type(self.caught),
             org=self.org.login,
             e=str(self.caught)
         ))

--- a/codekit/pygithub.py
+++ b/codekit/pygithub.py
@@ -86,6 +86,32 @@ class CaughtOrganizationError(Exception):
         ))
 
 
+class CaughtUnknownObjectError(Exception):
+    """Simple exception class intended to bundle together the name of the
+    resource that was attempted to be accessed and a thrown exception.
+    """
+    def __init__(self, name, caught):
+        assert isinstance(name, str), type(name)
+        assert isinstance(
+            caught,
+            github.UnknownObjectException
+        ), type(caught)
+
+        self.name = name
+        self.caught = caught
+
+    def __str__(self):
+        return textwrap.dedent("""\
+            Caught: {cls}
+              Name: {name}
+              Message: {e}\
+            """.format(
+            cls=type(self.caught),
+            name=self.name,
+            e=str(self.caught)
+        ))
+
+
 @public
 def login_github(token_path=None, token=None):
     """Log into GitHub using an existing token.

--- a/codekit/pygithub.py
+++ b/codekit/pygithub.py
@@ -241,9 +241,7 @@ def get_teams_by_name(org, team_names):
     github.GithubException
         Upon error from github api
     """
-    assert isinstance(org, github.Organization.Organization),\
-        type(org)
-    assert isinstance(team_names, list), type(team_names)
+    assert isinstance(org, github.Organization.Organization), type(org)
 
     org_teams = list(org.get_teams())
 

--- a/codekit/pygithub.py
+++ b/codekit/pygithub.py
@@ -112,6 +112,29 @@ class CaughtUnknownObjectError(Exception):
         ))
 
 
+class RepositoryTeamMembershipError(Exception):
+    def __init__(self, repo, repo_team_names, allow_teams, deny_teams):
+        assert isinstance(repo, github.Repository.Repository), type(repo)
+
+        self.repo = repo
+        self.repo_team_names = repo_team_names
+        self.allow_teams = allow_teams
+        self.deny_teams = deny_teams
+
+    def __str__(self):
+        return textwrap.dedent("""\
+            Invalid team membership for {repo}
+              has teams:     {repo_teams}
+              allowed teams: {allow}
+              denied teams:  {deny}\
+            """.format(
+            repo=self.repo.full_name,
+            repo_teams=self.repo_team_names,
+            allow=self.allow_teams,
+            deny=self.deny_teams,
+        ))
+
+
 @public
 def login_github(token_path=None, token=None):
     """Log into GitHub using an existing token.

--- a/codekit/pygithub.py
+++ b/codekit/pygithub.py
@@ -274,3 +274,44 @@ def debug_ratelimit(g):
     assert isinstance(g, github.MainClass.Github), type(g)
 
     debug("github ratelimit: {rl}".format(rl=g.rate_limiting))
+
+
+@public
+def check_repo_teams(repo, allow_teams, deny_teams, team_names=None):
+    """Check if repo teams match allow/deny lists
+
+    Parameters
+    ----------
+    repo: github.Repository.Repository
+        repo to check for membership
+
+    allow_teams: list(str)
+        list of team names that repo MUST belong to at least one of.
+
+    deny_teams: list(str)
+        list of team that repo MSUT NOT be a member of.
+
+    team_names: list(str)
+        list of the team name which the repo is a member of (optional).
+        Providing this list saves retriving the list of teams from the github
+        API.
+
+    Raises
+    ------
+    RepositoryTeamMembershipError
+        Upon permission error
+    """
+    assert isinstance(repo, github.Repository.Repository), type(repo)
+
+    # fetch team names if a list was not passed
+    if not team_names:
+        team_names = [t.name for t in repo.get_teams()]
+
+    if not any(x in team_names for x in allow_teams)\
+       or any(x in team_names for x in deny_teams):
+        raise RepositoryTeamMembershipError(
+            repo,
+            team_names,
+            allow_teams=allow_teams,
+            deny_teams=deny_teams
+        )

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'MapGitConfig==1.1',
         'progressbar2==3.37.1',
         'public==1.0',
-        'pygithub',
+        'pygithub==1.40a3',
         'requests>=2.8.1,<3.0.0',
     ],
     setup_requires=[


### PR DESCRIPTION
`github-tag-version` and `github-tag-team` and modified to allow team whitelist and blacklisting, in addition to doing more sanity checking before attempting to modify repo state.