### PR TITLE
rename github-tag-version -> github-tag-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
       python: '3.6'
       install: pip install --upgrade 'pip>=9' setuptools_scm
       script: python setup.py test
-    - env: TEST='github-tag-version --dry-run'
+    - env: TEST='github-tag-release --dry-run'
       language: python
       python: '3.6'
       install:
@@ -18,7 +18,7 @@ matrix:
         if [[ $TRAVIS_SECURE_ENV_VARS == true ]]; then
           # verify a past weekly tag -- the eups tag name and git tag names are
           # in sync except for s/_/-/
-          github-tag-version \
+          github-tag-release \
             --dry-run \
             --verify \
             --debug \
@@ -39,7 +39,7 @@ matrix:
           # verify a past official release where the git tag was generated from
           # an rcX eups tag.  This validates the location of the git tags but
           # does not inspect the official eups release tag at all.
-          github-tag-version \
+          github-tag-release \
             --dry-run \
             --verify \
             --debug \
@@ -61,7 +61,7 @@ matrix:
           # product version strings will be out of sync between the versiondb
           # manifest it was based on and the eups tag, the eups product version
           # strings have to be ignored.
-          github-tag-version \
+          github-tag-release \
             --dry-run \
             --verify \
             --debug \

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ running any command, or use the `-d` debug flag on the command line.
 - `github-fork-org`: fork repositories from one GitHub organization to another.
 - `github-list-repos`: list repositories in a GitHub organization, showing teams.
 - `github-mv-repos-to-team`: move repositories from one team to another.
-- `github-tag-version`: tag all repositories in a GitHub org using a team-based scheme.
-- `lsst-bp`: upgrade LSST DM code to [RFC-45](https://jira.lsstcorp.org/browse/RFC-45)-style.
+- `github-tag-release`: Tag git repositories, in a GitHub org, that correspond
+    to the products in a published eups distrib tag.
 
 Use the `--help` flag with any command to learn more.
 

--- a/codekit/cli/github_tag_release.py
+++ b/codekit/cli/github_tag_release.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python3
-"""
-Use URL to EUPS candidate tag file to git tag repos with official version
-"""
 
 # Technical Debt
 # --------------
@@ -37,20 +34,21 @@ def parse_args():
     """Parse command-line arguments"""
 
     parser = argparse.ArgumentParser(
-        prog='github-tag-version',
+        prog='github-tag-release',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description=textwrap.dedent("""
 
-        Tag all repositories in a GitHub org using a team-based scheme
+        Tag git repositories, in a GitHub org, that correspond to the products
+        in a published eups distrib tag.
 
         Examples:
-        github-tag-version \\
+        github-tag-release \\
             --org lsst \\
             --allow-team 'Data Management' \\
             --allow-team 'DM Externals' \\
             'w.2018.18' 'b3595'
 
-        github-tag-version \\
+        github-tag-release \\
             --org lsst \\
             --allow-team 'Data Management' \\
             --allow-team 'DM Externals' \\

--- a/codekit/cli/github_tag_teams.py
+++ b/codekit/cli/github_tag_teams.py
@@ -298,7 +298,7 @@ def create_tags(repo, tags, tagger, dry_run=False):
 
         tag_obj = repo.create_git_tag(
             t,
-            "Version {t}".format(t=t),  # fmt similar to github-tag-version
+            "Version {t}".format(t=t),  # fmt similar to github-tag-release
             head.object.sha,
             head.object.type,
             tagger=tagger

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install sqre-codekit=="$CODEKIT_VER" --no-cache-dir
 RUN useradd -m codekit
 USER codekit
 
-CMD ["/usr/local/bin/github-tag-version"]
+CMD ["/usr/local/bin/github-tag-release"]

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,8 @@ setup(
             'github-get-ratelimit= codekit.cli.github_get_ratelimit:main',
             'github-list-repos = codekit.cli.github_list_repos:main',
             'github-mv-repos-to-team = codekit.cli.github_mv_repos_to_team:main',  # NOQA
+            'github-tag-release = codekit.cli.github_tag_release:main',
             'github-tag-teams = codekit.cli.github_tag_teams:main',
-            'github-tag-version = codekit.cli.github_tag_version:main',
         ]
     }
 )


### PR DESCRIPTION
Using `release` as the noun in the <service>-<verb>-<noun> pattern this
package loosely follows make the purpose of this command slightly more
obvious.