### PR TITLE
improve handle of github http errors

### DIFF
--- a/codekit/cli/github_decimate_org.py
+++ b/codekit/cli/github_decimate_org.py
@@ -89,7 +89,14 @@ def delete_all_repos(org, **kwargs):
     assert isinstance(org, github.Organization.Organization), type(org)
     limit = kwargs.pop('limit', None)
 
-    repos = list(itertools.islice(org.get_repos(), limit))
+    try:
+        repos = list(itertools.islice(org.get_repos(), limit))
+    except github.RateLimitExceededException:
+        raise
+    except github.GithubException as e:
+        msg = 'error getting repos'
+        raise pygithub.CaughtOrganizationError(org, e, msg) from None
+
     info("found {n} repos in {org}".format(n=len(repos), org=org.login))
     [debug("  {r}".format(r=r.full_name)) for r in repos]
 

--- a/codekit/cli/github_decimate_org.py
+++ b/codekit/cli/github_decimate_org.py
@@ -133,7 +133,14 @@ def delete_all_teams(org, **kwargs):
     assert isinstance(org, github.Organization.Organization), type(org)
     limit = kwargs.pop('limit', None)
 
-    teams = list(itertools.islice(org.get_teams(), limit))
+    try:
+        teams = list(itertools.islice(org.get_teams(), limit))
+    except github.RateLimitExceededException:
+        raise
+    except github.GithubException as e:
+        msg = 'error getting teams'
+        raise pygithub.CaughtOrganizationError(org, e, msg) from None
+
     info("found {n} teams in {org}".format(n=len(teams), org=org.login))
     [debug("  '{t}'".format(t=t.name)) for t in teams]
 

--- a/codekit/cli/github_decimate_org.py
+++ b/codekit/cli/github_decimate_org.py
@@ -119,8 +119,8 @@ def delete_repos(repos, fail_fast=False, dry_run=False, delay=0):
         except github.RateLimitExceededException:
             raise
         except github.GithubException as e:
-            error('FAILED - does your token have delete_repo scope?')
-            yikes = pygithub.CaughtRepositoryError(r, e)
+            msg = 'FAILED - does your token have delete_repo scope?'
+            yikes = pygithub.CaughtRepositoryError(r, e, msg)
             if fail_fast:
                 raise yikes from None
             problems.append(yikes)

--- a/codekit/cli/github_fork_org.py
+++ b/codekit/cli/github_fork_org.py
@@ -103,7 +103,14 @@ def find_teams_by_repo(src_repos):
 
     src_rt = {}
     for r in src_repos:
-        teams = r.get_teams()
+        try:
+            teams = r.get_teams()
+        except github.RateLimitExceededException:
+            raise
+        except github.GithubException as e:
+            msg = 'error getting teams'
+            raise pygithub.CaughtRepositoryError(r, e, msg) from None
+
         team_names = [t.name for t in teams]
         debug("  {repo: >{w}} {teams}".format(
             repo=r.full_name,

--- a/codekit/cli/github_list_repos.py
+++ b/codekit/cli/github_list_repos.py
@@ -83,7 +83,15 @@ def run():
 
     org = g.get_organization(args.organization)
 
-    for r in org.get_repos():
+    try:
+        repos = list(org.get_repos())
+    except github.RateLimitExceededException:
+        raise
+    except github.GithubException as e:
+        msg = 'error getting repos'
+        raise pygithub.CaughtOrganizationError(org, e, msg) from None
+
+    for r in repos:
         try:
             teamnames = [t.name for t in r.get_teams()
                          if t.name not in args.hide]

--- a/codekit/cli/github_list_repos.py
+++ b/codekit/cli/github_list_repos.py
@@ -3,6 +3,7 @@
 from codekit.codetools import debug, error
 from codekit import codetools, pygithub
 import argparse
+import github
 import os
 import sys
 import textwrap
@@ -83,8 +84,15 @@ def run():
     org = g.get_organization(args.organization)
 
     for r in org.get_repos():
-        teamnames = [t.name for t in r.get_teams()
-                     if t.name not in args.hide]
+        try:
+            teamnames = [t.name for t in r.get_teams()
+                         if t.name not in args.hide]
+        except github.RateLimitExceededException:
+            raise
+        except github.GithubException as e:
+            msg = 'error getting teams'
+            raise pygithub.CaughtRepositoryError(r, e, msg) from None
+
         maxt = args.maxt if (args.maxt is not None and
                              args.maxt >= 0) else len(teamnames)
         if args.debug:

--- a/codekit/cli/github_mv_repos_to_team.py
+++ b/codekit/cli/github_mv_repos_to_team.py
@@ -98,7 +98,14 @@ def run():
     org = g.get_organization(args.org)
 
     # only iterate over all teams once
-    teams = list(org.get_teams())
+    try:
+        teams = list(org.get_teams())
+    except github.RateLimitExceededException:
+        raise
+    except github.GithubException as e:
+        msg = 'error getting teams'
+        raise pygithub.CaughtOrganizationError(org, e, msg) from None
+
     old_team = find_team(teams, args.oldteam)
     new_team = find_team(teams, args.newteam)
 

--- a/codekit/cli/github_mv_repos_to_team.py
+++ b/codekit/cli/github_mv_repos_to_team.py
@@ -115,7 +115,13 @@ def run():
     added = []
     removed = []
     for name in move_me:
-        r = org.get_repo(name)
+        try:
+            r = org.get_repo(name)
+        except github.RateLimitExceededException:
+            raise
+        except github.GithubException as e:
+            msg = "error getting repo by name: {r}".format(r=name)
+            raise pygithub.CaughtOrganizationError(org, e, msg) from None
 
         # Add team to the repo
         debug("Adding {repo} to '{team}' ...".format(

--- a/codekit/cli/github_tag_release.py
+++ b/codekit/cli/github_tag_release.py
@@ -473,10 +473,20 @@ def check_existing_git_tag(repo, t_tag, **kwargs):
         return False
 
     # find tag object pointed to by the ref
-    e_tag = repo.get_git_tag(e_ref.object.sha)
+    try:
+        e_tag = repo.get_git_tag(e_ref.object.sha)
+    except github.RateLimitExceededException:
+        raise
+    except github.GithubException as e:
+        msg = "error getting tag: {tag} [{sha}]".format(
+            tag=e_tag.tag,
+            sha=e_tag.sha,
+        )
+        raise pygithub.CaughtRepositoryError(repo, e, msg) from None
+
     debug("  found existing: {tag} [{sha}]".format(
         tag=e_tag.tag,
-        sha=e_tag.sha
+        sha=e_tag.sha,
     ))
 
     if cmp_existing_git_tag(t_tag, e_tag, **kwargs):

--- a/codekit/cli/github_tag_release.py
+++ b/codekit/cli/github_tag_release.py
@@ -339,7 +339,20 @@ def get_repo_for_products(
 
         debug("  found: {slug}".format(slug=repo.full_name))
 
-        repo_team_names = [t.name for t in repo.get_teams()]
+        try:
+            repo_team_names = [t.name for t in repo.get_teams()]
+        except github.RateLimitExceededException:
+            raise
+        except github.GithubException as e:
+            msg = 'error getting teams'
+            yikes = pygithub.CaughtRepositoryError(repo, e, msg)
+            if fail_fast:
+                raise yikes from None
+            problems.append(yikes)
+            error(yikes)
+
+            continue
+
         debug("  teams: {teams}".format(teams=repo_team_names))
 
         try:

--- a/codekit/cli/github_tag_release.py
+++ b/codekit/cli/github_tag_release.py
@@ -328,8 +328,11 @@ def get_repo_for_products(
 
         try:
             repo = org.get_repo(name)
-        except github.UnknownObjectException as e:
-            yikes = pygithub.CaughtUnknownObjectError(name, e)
+        except github.RateLimitExceededException:
+            raise
+        except github.GithubException as e:
+            msg = "error getting repo by name: {r}".format(r=name)
+            yikes = pygithub.CaughtOrganizationError(org, e, msg)
             if fail_fast:
                 raise yikes from None
             problems.append(yikes)

--- a/codekit/cli/github_tag_release.py
+++ b/codekit/cli/github_tag_release.py
@@ -568,7 +568,10 @@ def check_product_tags(
                 error(e)
                 continue
         except github.GithubException as e:
-            yikes = pygithub.CaughtRepositoryError(repo, e)
+            msg = "error checking for existance of tag: {t}".format(
+                t=t_tag.name,
+            )
+            yikes = pygithub.CaughtRepositoryError(repo, e, msg)
 
             if fail_fast:
                 raise yikes from None
@@ -672,7 +675,8 @@ def tag_products(
         except github.RateLimitExceededException:
             raise
         except github.GithubException as e:
-            yikes = pygithub.CaughtRepositoryError(repo, e)
+            msg = "error creating tag: {t}".format(t=t_tag.name)
+            yikes = pygithub.CaughtRepositoryError(repo, e, msg)
             if fail_fast:
                 raise yikes from None
             problems.append(yikes)

--- a/codekit/cli/github_tag_teams.py
+++ b/codekit/cli/github_tag_teams.py
@@ -211,8 +211,15 @@ def find_repo_teams(repo):
     if repo.full_name in cached_teams:
         return cached_teams[repo.full_name]
 
-    # flatten iterator so the results are cached
-    teams = list(repo.get_teams())
+    try:
+        # flatten iterator so the results are cached
+        teams = list(repo.get_teams())
+    except github.RateLimitExceededException:
+        raise
+    except github.GithubException as e:
+        msg = 'error getting teams'
+        raise pygithub.CaughtRepositoryError(repo, e, msg) from None
+
     cached_teams[repo.full_name] = teams
 
     return teams

--- a/codekit/cli/github_tag_teams.py
+++ b/codekit/cli/github_tag_teams.py
@@ -318,8 +318,16 @@ def create_tags(repo, tags, tagger, dry_run=False):
     # tag the head of the designated "default branch"
     # XXX this probably should be resolved via repos.yaml
     default_branch = repo.default_branch
-    head = repo.get_git_ref("heads/{ref}".format(
-        ref=default_branch))
+    default_branch_ref = "heads/{ref}".format(ref=default_branch)
+
+    try:
+        # if accessing the default branch fails something is serously wrong
+        head = repo.get_git_ref(default_branch_ref)
+    except github.RateLimitExceededException:
+        raise
+    except github.GithubException as e:
+        msg = "error getting ref: {ref}".format(ref=default_branch_ref)
+        raise pygithub.CaughtRepositoryError(repo, e, msg) from None
 
     debug(textwrap.dedent("""\
         tagging repo: {repo} @

--- a/codekit/cli/github_tag_teams.py
+++ b/codekit/cli/github_tag_teams.py
@@ -228,7 +228,13 @@ def find_repo_teams(repo):
 def get_candidate_teams(org, target_teams):
     assert isinstance(org, github.Organization.Organization), type(org)
 
-    teams = org.get_teams()
+    try:
+        teams = list(org.get_teams())
+    except github.RateLimitExceededException:
+        raise
+    except github.GithubException as e:
+        msg = 'error getting teams'
+        raise pygithub.CaughtOrganizationError(org, e, msg) from None
 
     debug("looking for teams: {teams}".format(teams=target_teams))
     tag_teams = [t for t in teams if t.name in target_teams]

--- a/codekit/pygithub.py
+++ b/codekit/pygithub.py
@@ -95,32 +95,6 @@ class CaughtOrganizationError(Exception):
         ))
 
 
-class CaughtUnknownObjectError(Exception):
-    """Simple exception class intended to bundle together the name of the
-    resource that was attempted to be accessed and a thrown exception.
-    """
-    def __init__(self, name, caught):
-        assert isinstance(name, str), type(name)
-        assert isinstance(
-            caught,
-            github.UnknownObjectException
-        ), type(caught)
-
-        self.name = name
-        self.caught = caught
-
-    def __str__(self):
-        return textwrap.dedent("""\
-            Caught: {cls}
-              Name: {name}
-              Message: {e}\
-            """.format(
-            cls=type(self.caught),
-            name=self.name,
-            e=str(self.caught)
-        ))
-
-
 class RepositoryTeamMembershipError(Exception):
     def __init__(self, repo, repo_team_names, allow_teams, deny_teams):
         assert isinstance(repo, github.Repository.Repository), type(repo)

--- a/codekit/pygithub.py
+++ b/codekit/pygithub.py
@@ -24,18 +24,20 @@ class CaughtRepositoryError(Exception):
     """Simple exception class intended to bundle together a
     github.Repository.Repository object and a thrown exception
     """
-    def __init__(self, repo, caught):
+    def __init__(self, repo, caught, msg):
         assert isinstance(repo, github.Repository.Repository), type(repo)
         assert isinstance(caught, github.GithubException), type(caught)
 
         self.repo = repo
         self.caught = caught
+        self.msg = msg
 
     def __str__(self):
         return textwrap.dedent("""\
             Caught: {cls}
               In repo: {repo}
-              Message: {e}\
+              Message: {msg}
+              Exception Message: {e}\
             """.format(
             cls=type(self.caught),
             repo=self.repo.full_name,

--- a/codekit/pygithub.py
+++ b/codekit/pygithub.py
@@ -287,7 +287,13 @@ def get_teams_by_name(org, team_names):
     """
     assert isinstance(org, github.Organization.Organization), type(org)
 
-    org_teams = list(org.get_teams())
+    try:
+        org_teams = list(org.get_teams())
+    except github.RateLimitExceededException:
+        raise
+    except github.GithubException as e:
+        msg = 'error getting teams'
+        raise CaughtOrganizationError(org, e, msg) from None
 
     found_teams = []
     for name in team_names:

--- a/codekit/pygithub.py
+++ b/codekit/pygithub.py
@@ -349,7 +349,13 @@ def check_repo_teams(repo, allow_teams, deny_teams, team_names=None):
 
     # fetch team names if a list was not passed
     if not team_names:
-        team_names = [t.name for t in repo.get_teams()]
+        try:
+            team_names = [t.name for t in repo.get_teams()]
+        except github.RateLimitExceededException:
+            raise
+        except github.GithubException as e:
+            msg = 'error getting teams'
+            raise CaughtRepositoryError(repo, e, msg) from None
 
     if not any(x in team_names for x in allow_teams)\
        or any(x in team_names for x in deny_teams):


### PR DESCRIPTION
In particular, github likes to return http 404 when a token is not authorized
to access a resource.  A common example of this is attempting to list the teams
a repo is a member of without the 'owner' role.  Further, as pygithub exceptions do not report the name of the object (org,repo,etc.) that generated the exception, wrapper exception classes are needed to provide useful debugging information.