### PR TITLE
DM-32592: Unpin Python.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,10 @@
-FROM docker.io/python:3.6.3
+FROM docker.io/python:3
 
 ARG CODEKIT_VER=4.0.1
 
 USER root
 RUN pip install sqre-codekit=="$CODEKIT_VER" --no-cache-dir
-
+# hadolint ignore=DL3059
 RUN useradd -m codekit
 USER codekit
 WORKDIR /home/codekit


### PR DESCRIPTION
Among other things, this provides a newer CA cert list than Debian jessie (currently oldoldstable 20141019).