### PR TITLE
DM-32592: Pin Python version to 3.9.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/python:3
+FROM docker.io/python:3.8
 
 ARG CODEKIT_VER=4.0.1
 


### PR DESCRIPTION
`MutableMapping` cannot be imported from `collections` after that version.

The dependencies in `setup.py` could be updated, but that is more than I'd like to take on right now.